### PR TITLE
초대코드 연동 로직 구현 및 주석문 추가

### DIFF
--- a/Routory/Routory/Data/Repositories/CalendarRepository.swift
+++ b/Routory/Routory/Data/Repositories/CalendarRepository.swift
@@ -1,0 +1,17 @@
+//
+//  CalendarRepository.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+final class CalendarRepository: CalendarRepositoryProtocol {
+    private let calendarService: CalendarServiceProtocol
+    init(calendarService: CalendarServiceProtocol) {
+        self.calendarService = calendarService
+    }
+    func addUserToCalendarSharedWith(calendarId: String, uid: String) -> Observable<Void> {
+        calendarService.addUserToCalendarSharedWith(calendarId: calendarId, uid: uid)
+    }
+}

--- a/Routory/Routory/Data/Repositories/UserRepository.swift
+++ b/Routory/Routory/Data/Repositories/UserRepository.swift
@@ -42,4 +42,8 @@ final class UserRepository: UserRepositoryProtocol {
                 uid: uid
             )
         }
+    
+    func addWorkplaceToUser(uid: String, workplaceId: String) -> Observable<Void> {
+        return userService.addWorkplaceToUser(uid: uid, workplaceId: workplaceId)
+    }
 }

--- a/Routory/Routory/Data/Repositories/WorkplaceRepository.swift
+++ b/Routory/Routory/Data/Repositories/WorkplaceRepository.swift
@@ -1,0 +1,20 @@
+//
+//  WorkplaceRepository.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+final class WorkplaceRepository: WorkplaceRepositoryProtocol {
+    private let service: WorkplaceServiceProtocol
+    init(service: WorkplaceServiceProtocol) {
+        self.service = service
+    }
+    func fetchWorkplaceByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?> {
+        service.fetchWorkplaceByInviteCode(inviteCode: inviteCode)
+    }
+    func addWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void> {
+        service.addWorkerToWorkplace(workplaceId: workplaceId, uid: uid, workerDetail: workerDetail)
+    }
+}

--- a/Routory/Routory/Data/Services/CalendarService.swift
+++ b/Routory/Routory/Data/Services/CalendarService.swift
@@ -15,6 +15,13 @@ protocol CalendarServiceProtocol {
 final class CalendarService: CalendarServiceProtocol {
     private let db = Firestore.firestore()
     
+    /// 캘린더의 sharedWith 배열에 사용자의 uid를 추가합니다.
+    ///
+    /// - Parameters:
+    ///   - calendarId: 공유할 캘린더의 Firestore documentID
+    ///   - uid: 공유에 추가할 사용자 UID
+    /// - Returns: 성공 시 완료(Void)를 방출하는 Observable
+    /// - Firestore 경로: calendars/{calendarId}/sharedWith (arrayUnion)
     func addUserToCalendarSharedWith(calendarId: String, uid: String) -> Observable<Void> {
         let calendarRef = db.collection("calendars").document(calendarId)
         return Observable.create { observer in

--- a/Routory/Routory/Data/Services/CalendarService.swift
+++ b/Routory/Routory/Data/Services/CalendarService.swift
@@ -1,0 +1,34 @@
+//
+//  CalendarService.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+
+import RxSwift
+import FirebaseFirestore
+
+protocol CalendarServiceProtocol {
+    func addUserToCalendarSharedWith(calendarId: String, uid: String) -> Observable<Void>
+}
+
+final class CalendarService: CalendarServiceProtocol {
+    private let db = Firestore.firestore()
+    
+    func addUserToCalendarSharedWith(calendarId: String, uid: String) -> Observable<Void> {
+        let calendarRef = db.collection("calendars").document(calendarId)
+        return Observable.create { observer in
+            calendarRef.updateData([
+                "sharedWith": FieldValue.arrayUnion([uid])
+            ]) { error in
+                if let error = error {
+                    observer.onError(error)
+                } else {
+                    observer.onNext(())
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/Routory/Routory/Data/Services/RoutineService.swift
+++ b/Routory/Routory/Data/Services/RoutineService.swift
@@ -19,6 +19,11 @@ protocol RoutineServiceProtocol {
 final class RoutineService: RoutineServiceProtocol {
     private let db = Firestore.firestore()
     
+    /// 지정된 사용자의 모든 루틴을 조회합니다.
+    ///
+    /// - Parameter uid: 루틴을 조회할 사용자 UID
+    /// - Returns: RoutineInfo(루틴ID+루틴정보) 배열을 방출하는 Observable
+    /// - Firestore 경로: users/{userId}/routine
     func fetchAllRoutines(uid: String) -> Observable<[RoutineInfo]> {
         return Observable.create { observer in
             self.db.collection("users").document(uid).collection("routine")
@@ -51,7 +56,13 @@ final class RoutineService: RoutineServiceProtocol {
         }
     }
     
-    /// 루틴 등록 (루틴 ID 자동 생성, 성공 시 해당 ID 반환)
+    /// 사용자의 루틴을 새로 등록합니다.
+    ///
+    /// - Parameters:
+    ///   - uid: 루틴을 등록할 사용자 UID
+    ///   - routine: 등록할 Routine 모델
+    /// - Returns: 성공 시 완료(Void)를 방출하는 Observable
+    /// - Firestore 경로: users/{userId}/routine/{autoId}
     func createRoutine(uid: String, routine: Routine) -> Observable<Void> {
         return Observable.create { observer in
             
@@ -76,7 +87,13 @@ final class RoutineService: RoutineServiceProtocol {
         }
     }
     
-    /// 루틴 삭제
+    /// 사용자의 특정 루틴을 삭제합니다.
+    ///
+    /// - Parameters:
+    ///   - uid: 루틴을 삭제할 사용자 UID
+    ///   - routineId: 삭제할 루틴의 ID
+    /// - Returns: 성공 시 완료(Void)를 방출하는 Observable
+    /// - Firestore 경로: users/{userId}/routine/{routineId}
     func deleteRoutine(uid: String, routineId: String) -> Observable<Void> {
         return Observable.create { observer in
             let routineRef = self.db.collection("users").document(uid).collection("routine").document(routineId)
@@ -92,7 +109,14 @@ final class RoutineService: RoutineServiceProtocol {
         }
     }
     
-    /// 루틴 수정
+    /// 사용자의 특정 루틴 정보를 수정합니다.
+    ///
+    /// - Parameters:
+    ///   - uid: 루틴을 수정할 사용자 UID
+    ///   - routineId: 수정할 루틴의 ID
+    ///   - routine: 수정할 Routine 모델
+    /// - Returns: 성공 시 완료(Void)를 방출하는 Observable
+    /// - Firestore 경로: users/{userId}/routine/{routineId}
     func updateRoutine(uid: String, routineId: String, routine: Routine) -> Observable<Void> {
         return Observable.create { observer in
             let routineRef = self.db.collection("users").document(uid).collection("routine").document(routineId)

--- a/Routory/Routory/Data/Services/UserService.swift
+++ b/Routory/Routory/Data/Services/UserService.swift
@@ -26,6 +26,7 @@ protocol UserServiceProtocol {
             workerDetail: WorkerDetail?,
             uid: String
         ) -> Observable<String>
+    func addWorkplaceToUser(uid: String, workplaceId: String) -> Observable<Void>
 }
 
 final class UserService: UserServiceProtocol {
@@ -174,5 +175,21 @@ final class UserService: UserServiceProtocol {
                 return Disposables.create()
             }
         }
+    
+    func addWorkplaceToUser(uid: String, workplaceId: String) -> Observable<Void> {
+        return Observable.create { observer in
+            self.db.collection("users").document(uid)
+                .collection("workplaces").document(workplaceId)
+                .setData([:]) { error in
+                    if let error = error {
+                        observer.onError(error)
+                    } else {
+                        observer.onNext(())
+                        observer.onCompleted()
+                    }
+                }
+            return Disposables.create()
+        }
+    }
 
 }

--- a/Routory/Routory/Data/Services/WorkplaceService.swift
+++ b/Routory/Routory/Data/Services/WorkplaceService.swift
@@ -17,7 +17,11 @@ protocol WorkplaceServiceProtocol {
 final class WorkplaceService: WorkplaceServiceProtocol {
     private let db = Firestore.firestore()
     
-    /// 초대코드로 연동된 근무지 정보 반환
+    /// 초대코드를 통해 근무지 정보를 조회합니다.
+    ///
+    /// - Parameter inviteCode: 조회할 근무지의 초대코드
+    /// - Returns: 조회된 WorkplaceInfo(근무지 ID + 근무지 정보)를 방출하는 Observable, 없으면 nil
+    /// - Firestore 경로: workplaces (inviteCode 검색)
     func fetchWorkplaceByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?> {
         return Observable.create { observer in
             self.db.collection("workplaces")
@@ -46,6 +50,14 @@ final class WorkplaceService: WorkplaceServiceProtocol {
         }
     }
     
+    /// 근무지의 worker 서브컬렉션에 알바(워커) 정보를 등록합니다.
+    ///
+    /// - Parameters:
+    ///   - workplaceId: 근무지의 Firestore documentID
+    ///   - uid: 등록할 알바(유저) UID
+    ///   - workerDetail: 등록할 WorkerDetail 정보
+    /// - Returns: 성공 시 완료(Void)를 방출하는 Observable
+    /// - Firestore 경로: workplaces/{workplaceId}/worker/{uid}
     func addWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void> {
         let db = Firestore.firestore()
         return Observable.create { observer in

--- a/Routory/Routory/Data/Services/WorkplaceService.swift
+++ b/Routory/Routory/Data/Services/WorkplaceService.swift
@@ -1,0 +1,70 @@
+//
+//  WorkplaceService.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+
+import FirebaseFirestore
+import RxSwift
+
+protocol WorkplaceServiceProtocol {
+    func fetchWorkplaceByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?>
+    func addWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void>
+}
+
+
+final class WorkplaceService: WorkplaceServiceProtocol {
+    private let db = Firestore.firestore()
+    
+    /// 초대코드로 연동된 근무지 정보 반환
+    func fetchWorkplaceByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?> {
+        return Observable.create { observer in
+            self.db.collection("workplaces")
+                .whereField("inviteCode", isEqualTo: inviteCode)
+                .getDocuments { snapshot, error in
+                    if let error = error {
+                        observer.onError(error)
+                        return
+                    }
+                    guard let document = snapshot?.documents.first else {
+                        observer.onNext(nil)
+                        observer.onCompleted()
+                        return
+                    }
+                    let data = document.data()
+                    if let jsonData = try? JSONSerialization.data(withJSONObject: data),
+                       let workplace = try? JSONDecoder().decode(Workplace.self, from: jsonData) {
+                        let id = document.documentID
+                        observer.onNext(WorkplaceInfo(id: id, workplace: workplace))
+                    } else {
+                        observer.onNext(nil)
+                    }
+                    observer.onCompleted()
+                }
+            return Disposables.create()
+        }
+    }
+    
+    func addWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void> {
+        let db = Firestore.firestore()
+        return Observable.create { observer in
+            do {
+                let data = try Firestore.Encoder().encode(workerDetail)
+                db.collection("workplaces").document(workplaceId)
+                    .collection("worker").document(uid)
+                    .setData(data) { error in
+                        if let error = error {
+                            observer.onError(error)
+                        } else {
+                            observer.onNext(())
+                            observer.onCompleted()
+                        }
+                    }
+            } catch {
+                observer.onError(error)
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/Routory/Routory/Domain/Entities/Workplace.swift
+++ b/Routory/Routory/Domain/Entities/Workplace.swift
@@ -33,3 +33,10 @@ struct Workplace: Codable {
         self.isOfficial = isOfficial
     }
 }
+
+struct WorkplaceInfo: Codable {
+    
+    let id: String
+    let workplace: Workplace
+    
+}

--- a/Routory/Routory/Domain/Interfaces/Repositories/CalendarRepositoryProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/Repositories/CalendarRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  CalendarRepositoryProtocol.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+
+import RxSwift
+
+protocol CalendarRepositoryProtocol {
+    func addUserToCalendarSharedWith(calendarId: String, uid: String) -> Observable<Void>
+}

--- a/Routory/Routory/Domain/Interfaces/Repositories/UserRepositoryProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/Repositories/UserRepositoryProtocol.swift
@@ -18,4 +18,5 @@ protocol UserRepositoryProtocol {
             workerDetail: WorkerDetail?,
             uid: String
         ) -> Observable<String>
+    func addWorkplaceToUser(uid: String, workplaceId: String) -> Observable<Void>
 }

--- a/Routory/Routory/Domain/Interfaces/Repositories/WorkplaceRepositoryProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/Repositories/WorkplaceRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  WorkplaceRepositoryProtocol.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+protocol WorkplaceRepositoryProtocol {
+    func fetchWorkplaceByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?>
+    func addWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void>
+}

--- a/Routory/Routory/Domain/Interfaces/UseCases/CalendarUseCaseProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/UseCases/CalendarUseCaseProtocol.swift
@@ -1,0 +1,11 @@
+//
+//  CalendarUseCaseProtocol.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+protocol CalendarUseCaseProtocol {
+    func shareCalendarWithUser(calendarId: String, uid: String) -> Observable<Void>
+}

--- a/Routory/Routory/Domain/Interfaces/UseCases/UserUseCaseProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/UseCases/UserUseCaseProtocol.swift
@@ -18,4 +18,5 @@ protocol UserUseCaseProtocol {
             workerDetail: WorkerDetail?,
             uid: String
         ) -> Observable<String>
+    func addWorkplaceToUser(uid: String, workplaceId: String) -> Observable<Void>
 }

--- a/Routory/Routory/Domain/Interfaces/UseCases/WorkplaceUseCaseProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/UseCases/WorkplaceUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  Untitled.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+protocol WorkplaceUseCaseProtocol {
+    func getWorkplaceInfoByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?>
+    func registerWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void>
+}

--- a/Routory/Routory/Domain/UseCases/CalendarUseCase.swift
+++ b/Routory/Routory/Domain/UseCases/CalendarUseCase.swift
@@ -1,0 +1,17 @@
+//
+//  CalendarUseCase.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+final class CalendarUseCase: CalendarUseCaseProtocol {
+    private let repository: CalendarRepository
+    init(repository: CalendarRepository) {
+        self.repository = repository
+    }
+    func shareCalendarWithUser(calendarId: String, uid: String) -> Observable<Void> {
+        repository.addUserToCalendarSharedWith(calendarId: calendarId, uid: uid)
+    }
+}

--- a/Routory/Routory/Domain/UseCases/UserUseCase.swift
+++ b/Routory/Routory/Domain/UseCases/UserUseCase.swift
@@ -42,4 +42,7 @@ final class UserUseCase: UserUseCaseProtocol {
                 uid: uid
             )
         }
+    func addWorkplaceToUser(uid: String, workplaceId: String) -> Observable<Void> {
+        return userRepository.addWorkplaceToUser(uid: uid, workplaceId: workplaceId)
+    }
 }

--- a/Routory/Routory/Domain/UseCases/WorkplaceUseCase.swift
+++ b/Routory/Routory/Domain/UseCases/WorkplaceUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  WorkplaceUseCase.swift
+//  Routory
+//
+//  Created by 양원식 on 6/17/25.
+//
+import RxSwift
+
+final class WorkplaceUseCase: WorkplaceUseCaseProtocol {
+    private let repository: WorkplaceRepository
+    init(repository: WorkplaceRepository) {
+        self.repository = repository
+    }
+    func getWorkplaceInfoByInviteCode(inviteCode: String) -> Observable<WorkplaceInfo?> {
+        repository.fetchWorkplaceByInviteCode(inviteCode: inviteCode)
+    }
+    func registerWorkerToWorkplace(workplaceId: String, uid: String, workerDetail: WorkerDetail) -> Observable<Void> {
+        repository.addWorkerToWorkplace(workplaceId: workplaceId, uid: uid, workerDetail: workerDetail)
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #44 

</br>

## 📝 작업 내용
- 근무지 연동(등록) 시 아래 연관 기능을 순차적으로 처리하도록 구현
    - 1) 근무지의 worker 컬렉션에 내 워커 정보 등록 (`workplaces/{workplaceId}/worker/{userId}`)
    - 2) 내 근무지 리스트에 해당 근무지 문서 추가 (`users/{userId}/workplaces/{workplaceId}`)
    - 3) 캘린더의 sharedWith 배열에 내 userId 추가 (`calendars/{calendarId}/sharedWith`)
    
- 가독성을 위한 주석문 추가
