### PR TITLE
로딩 애니메이션 임시 구현 및 근무지 생성 직접 입력 분기 처리

### DIFF
--- a/Routory/Routory/Presentation/Components/LoadingAnimationView.swift
+++ b/Routory/Routory/Presentation/Components/LoadingAnimationView.swift
@@ -39,7 +39,7 @@ final class LoadingAnimationView: UIView {
         logoImageView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
         
         // 페이드인 + 스케일 애니메이션
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
+        UIView.animate(withDuration: 1.0, delay: 0, options: .curveEaseOut) {
             self.alpha = 1
             self.logoImageView.transform = .identity
         }
@@ -53,7 +53,7 @@ final class LoadingAnimationView: UIView {
         logoImageView.layer.removeAllAnimations()
         
         // 페이드아웃
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+        UIView.animate(withDuration: 1.0, delay: 0, options: .curveEaseInOut) {
             self.alpha = 0
             self.logoImageView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
         } completion: { _ in

--- a/Routory/Routory/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Routory/Routory/Presentation/Home/ViewController/HomeViewController.swift
@@ -128,6 +128,10 @@ private extension HomeViewController {
         
         // HomeView 버튼 이벤트 바인딩
         homeView.rx.refreshButtonTapped
+            .do (onNext: { _ in
+                LoadingManager.start()
+                print("로딩 시작됨")
+            })
             .bind(to: refreshBtnTappedRelay)
             .disposed(by: disposeBag)
 

--- a/Routory/Routory/Presentation/Home/ViewController/WorkplaceAddModalViewController.swift
+++ b/Routory/Routory/Presentation/Home/ViewController/WorkplaceAddModalViewController.swift
@@ -84,7 +84,30 @@ private extension WorkplaceAddModalViewController {
     }
     
     @objc func manualInputButtonDidTap() {
-        let vc = WorkerWorkplaceRegistrationViewController(mode: .fullRegistration)
-        navigationController?.pushViewController(vc, animated: true)
+        UserManager.shared.getUser { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let user):
+                switch UserType(role: user.role) {
+                case .worker:
+                    let vc = self.makeManualWorkplaceRegistrationVC(type: .worker)
+                    self.navigationController?.pushViewController(vc, animated: true)
+                case .owner:
+                    let vc = self.makeManualWorkplaceRegistrationVC(type: .owner)
+                    self.navigationController?.pushViewController(vc, animated: true)
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+
+    func makeManualWorkplaceRegistrationVC(type: UserType) -> UIViewController {
+        switch type {
+        case .worker:
+            return WorkerWorkplaceRegistrationViewController(mode: .fullRegistration)
+        case .owner:
+            return OwnerWorkplaceRegistrationViewController()
+        }
     }
 }

--- a/Routory/Routory/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Routory/Routory/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -19,6 +19,7 @@ final class HomeViewModel {
 
     // MARK: - Mock Data
     let dummyWorkplace = DummyWorkplaceInfo(
+        isOfficial: false,
         storeName: "맥도날드 강북 수유점",
         daysUntilPayday: 18,
         totalEarned: 252000,
@@ -90,6 +91,7 @@ final class HomeViewModel {
         input.refreshBtnTapped
             .subscribe(onNext: { [weak self] in
                 print("refreshBtnTapped - 데이터 새로고침")
+                LoadingManager.stop()
                 // 새로고침 시 확장 상태 초기화
                 self?.expandedIndexPathRelay.accept([])
             }).disposed(by: disposeBag)

--- a/Routory/Routory/Presentation/Routine/View/ManageRoutineView.swift
+++ b/Routory/Routory/Presentation/Routine/View/ManageRoutineView.swift
@@ -16,7 +16,7 @@ final class ManageRoutineView: UIView {
 
     // MARK: - UI Components
     fileprivate lazy var navigationBar = BaseNavigationBar(title: routineTitle)
-    fileprivate let tableView = UITableView().then {
+    let tableView = UITableView().then {
         $0.backgroundColor = .clear
         $0.separatorColor = .gray300
         $0.separatorInset = .zero
@@ -110,26 +110,6 @@ extension Reactive where Base: ManageRoutineView {
                     return cell
                 }
                 .disposed(by: view.disposeBag) // 적절한 disposeBag 사용 필요
-        }
-    }
-
-    var bindTodaysRoutines: Binder<[DummyTodaysRoutine]> {
-        return Binder(base) { view, routines in
-            Observable.just(routines)
-                .bind(to: view.tableView.rx.items) { tableView, index, routine in
-                    let indexPath = IndexPath(row: index, section: 0)
-
-                    guard let cell = tableView.dequeueReusableCell(
-                        withIdentifier: TodaysRoutineCell.identifier,
-                        for: indexPath
-                    ) as? TodaysRoutineCell else {
-                        return UITableViewCell()
-                    }
-                    cell.update(with: routine)
-
-
-                    return cell
-                }.disposed(by: view.disposeBag)
         }
     }
 

--- a/Routory/Routory/Presentation/Routine/View/WorkplaceRoutineView.swift
+++ b/Routory/Routory/Presentation/Routine/View/WorkplaceRoutineView.swift
@@ -16,7 +16,7 @@ class WorkplaceRoutineView: UIView {
 
     // MARK: - UI Components
     fileprivate lazy var navigationBar = BaseNavigationBar(title: workplaceTitle)
-    fileprivate let tableView = UITableView().then {
+    let tableView = UITableView().then {
         $0.backgroundColor = .clear
         $0.separatorColor = .gray300
         $0.separatorInset = .zero

--- a/Routory/Routory/Presentation/Routine/ViewModel/ManageRoutineViewModel.swift
+++ b/Routory/Routory/Presentation/Routine/ViewModel/ManageRoutineViewModel.swift
@@ -44,7 +44,7 @@ final class ManageRoutineViewModel {
 
     // MARK: - Input, Output
     struct Input {
-        let viewDidLoad: Observable<Void>
+        let refreshTriggered: Observable<Void>
     }
 
     struct Output {
@@ -58,7 +58,7 @@ final class ManageRoutineViewModel {
         switch routineType {
         case .today:
             print("오늘의 루틴 호출 시도")
-            let todayRoutines = input.viewDidLoad
+            let todayRoutines = input.refreshTriggered
                 .flatMapLatest { [weak self] _ -> Observable<[DummyTodaysRoutine]> in
                     print("flatMapLatest 진입")
                     guard let self else { print("self가 nil"); return .empty() }
@@ -71,7 +71,7 @@ final class ManageRoutineViewModel {
                 allRoutine: .just([])
             )
         case .all:
-            let allRoutines = input.viewDidLoad
+            let allRoutines = input.refreshTriggered
                 .flatMapLatest { [weak self] _ -> Observable<[RoutineInfo]> in
                     print("flatMapLatest 진입")
                     guard let self else { print("self가 nil"); return .empty() }

--- a/Routory/Routory/Presentation/Routine/ViewModel/WorkplaceRoutineViewModel.swift
+++ b/Routory/Routory/Presentation/Routine/ViewModel/WorkplaceRoutineViewModel.swift
@@ -33,12 +33,8 @@ final class WorkplaceRoutineViewModel {
 
     func transform(input: Input) -> Output {
         input.viewDidLoad
-            .do(onNext: {
-                print("viewModel - viewDidLoad 이벤트 수신됨")
-            })
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
-                print("viewDidLoad 호출됨")
                 self.routinesRelay.accept(self.workplaceRoutine.routines)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #54 

</br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 새로고침 탭 시 임시로 띄워줄 로딩 화면 구성
- 근무지 생성 내 직접 입력 탭 시 role에 따른 분기 처리
- 루틴 관리 이후 로직에 관해 생성 등 후 다시 전 페이지로 돌아오면 리로드를 원활하게 할 수 있게 임시 구현

</br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | ![Simulator Screen Recording - iPhone 13 mini - 2025-06-19 at 12 40 34](https://github.com/user-attachments/assets/20e084af-4679-4087-9de7-e926f31d9d7c) |

</br>
