### PR TITLE
근무지 수정 / 근무 수정

### DIFF
--- a/Routory/Routory/Data/Repositories/CalendarRepository.swift
+++ b/Routory/Routory/Data/Repositories/CalendarRepository.swift
@@ -25,4 +25,7 @@ final class CalendarRepository: CalendarRepositoryProtocol {
     func deleteEventFromCalendarIfPermitted(calendarId: String, eventId: String, uid: String) -> Observable<Void> {
         return calendarService.deleteEventFromCalendarIfPermitted(calendarId: calendarId, eventId: eventId, uid: uid)
     }
+    func updateEventInCalendar(calendarId: String, eventId: String, event: CalendarEvent) -> Observable<Void> {
+        return calendarService.updateEventInCalendar(calendarId: calendarId, eventId: eventId, event: event)
+    }
 }

--- a/Routory/Routory/Data/Repositories/WorkplaceRepository.swift
+++ b/Routory/Routory/Data/Repositories/WorkplaceRepository.swift
@@ -60,5 +60,21 @@ final class WorkplaceRepository: WorkplaceRepositoryProtocol {
     func deleteOrLeaveWorkplace(workplaceId: String, uid: String) -> Observable<Void> {
         return service.deleteOrLeaveWorkplace(workplaceId: workplaceId, uid: uid)
     }
+    
+    func updateWorkerDetailAndColor(
+        workplaceId: String,
+        uid: String,
+        workerDetail: WorkerDetail,
+        color: String
+    ) -> Observable<Void> {
+        return service.updateWorkerDetailAndColor(workplaceId: workplaceId, uid: uid, workerDetail: workerDetail, color: color)
+    }
 
+    func updateWorkplaceNameAndCategory(
+        workplaceId: String,
+        name: String,
+        category: String
+    ) -> Observable<Void> {
+        return service.updateWorkplaceNameAndCategory(workplaceId: workplaceId, name: name, category: category)
+    }
 }

--- a/Routory/Routory/Data/Services/WorkplaceService.swift
+++ b/Routory/Routory/Data/Services/WorkplaceService.swift
@@ -642,8 +642,22 @@ final class WorkplaceService: WorkplaceServiceProtocol {
                 "workplacesName": name,
                 "category": category
             ]) { error in
-                if let error = error {
-                    observer.onError(error)
+                if let error = error as NSError? {
+                    if error.domain == FirestoreErrorDomain,
+                       error.code == FirestoreErrorCode.permissionDenied.rawValue {
+                        // 파이어스토어 권한 에러 (보안 규칙 위반)
+                        observer.onError(
+                            NSError(
+                                domain: "CustomErrorDomain",
+                                code: error.code,
+                                userInfo: [
+                                    NSLocalizedDescriptionKey: "권한이 없습니다. Firestore Security Rule에 의해 거부되었습니다."
+                                ]
+                            )
+                        )
+                    } else {
+                        observer.onError(error)
+                    }
                 } else {
                     observer.onNext(())
                     observer.onCompleted()
@@ -652,4 +666,5 @@ final class WorkplaceService: WorkplaceServiceProtocol {
             return Disposables.create()
         }
     }
+
 }

--- a/Routory/Routory/Data/Services/WorkplaceService.swift
+++ b/Routory/Routory/Data/Services/WorkplaceService.swift
@@ -31,6 +31,17 @@ protocol WorkplaceServiceProtocol {
         month: Int
     ) -> Observable<[WorkplaceWorkSummaryDaily]>
     func deleteOrLeaveWorkplace(workplaceId: String, uid: String) -> Observable<Void>
+    func updateWorkerDetailAndColor(
+        workplaceId: String,
+        uid: String,
+        workerDetail: WorkerDetail,
+        color: String
+    ) -> Observable<Void>
+    func updateWorkplaceNameAndCategory(
+        workplaceId: String,
+        name: String,
+        category: String
+    ) -> Observable<Void>
 }
 
 
@@ -421,7 +432,7 @@ final class WorkplaceService: WorkplaceServiceProtocol {
             }
             return Disposables.create()
         }
-
+        
         return workplaceObs
             .flatMap { (ownerUid, calendarId) -> Observable<Void> in
                 // 오너 == 전체 삭제
@@ -430,17 +441,17 @@ final class WorkplaceService: WorkplaceServiceProtocol {
                 } else {
                     // 워커 == 내 정보, 내가 만든 이벤트만 삭제 + 내 workplaces 문서도 삭제 + sharedWith에서 uid 삭제
                     let batch = self.db.batch()
-
+                    
                     // 1. workplaces/{workplaceId}/workers/{myUid}
                     let workerRef = self.db.collection("workplaces").document(workplaceId)
                         .collection("workers").document(uid)
                     batch.deleteDocument(workerRef)
-
+                    
                     // 2. users/{myUid}/workplaces/{workplaceId} (내 workplaces 문서 삭제)
                     let myWorkplaceRef = self.db.collection("users").document(uid)
                         .collection("workplaces").document(workplaceId)
                     batch.deleteDocument(myWorkplaceRef)
-
+                    
                     // 3. calendars/{calendarId}/events 중 내가 만든(createdBy == myUid) 이벤트만 삭제
                     if let calendarId = calendarId {
                         let eventsRef = self.db.collection("calendars").document(calendarId).collection("events")
@@ -499,7 +510,7 @@ final class WorkplaceService: WorkplaceServiceProtocol {
                 }
             }
     }
-
+    
     // 오너 전체 삭제
     private func deleteWorkplaceAndReferences(workplaceId: String, calendarId: String?) -> Observable<Void> {
         // 1. workers 서브컬렉션 모든 문서 삭제 + uid 목록 수집
@@ -526,28 +537,28 @@ final class WorkplaceService: WorkplaceServiceProtocol {
             }
             return Disposables.create()
         }
-
+        
         // 2. workers 삭제 후, workplace/캘린더/유저 workplaces 문서/이벤트 삭제
         return deleteWorkersObs.flatMap { uids -> Observable<Void> in
             let batch = self.db.batch()
-
+            
             // workplaces/{workplaceId}
             let workplaceRef = self.db.collection("workplaces").document(workplaceId)
             batch.deleteDocument(workplaceRef)
-
+            
             // calendars/{calendarId}
             if let calendarId = calendarId {
                 let calendarRef = self.db.collection("calendars").document(calendarId)
                 batch.deleteDocument(calendarRef)
             }
-
+            
             // users/{uid}/workplaces/{workplaceId} (모든 워커의 workplaces 문서 삭제)
             for uid in uids {
                 let userWorkplaceRef = self.db.collection("users").document(uid)
                     .collection("workplaces").document(workplaceId)
                 batch.deleteDocument(userWorkplaceRef)
             }
-
+            
             // batch commit → 이후 events 서브컬렉션 삭제
             return Observable.create { observer in
                 batch.commit { error in
@@ -582,6 +593,63 @@ final class WorkplaceService: WorkplaceServiceProtocol {
                 }
                 return Disposables.create()
             }
+        }
+    }
+    
+    func updateWorkerDetailAndColor(
+        workplaceId: String,
+        uid: String,
+        workerDetail: WorkerDetail,
+        color: String
+    ) -> Observable<Void> {
+        let workerRef = db.collection("workplaces").document(workplaceId)
+            .collection("worker").document(uid)
+        let userWorkplaceRef = db.collection("users").document(uid)
+            .collection("workplaces").document(workplaceId)
+        
+        return Observable.create { observer in
+            let batch = self.db.batch()
+            do {
+                let workerData = try Firestore.Encoder().encode(workerDetail)
+                batch.setData(workerData, forDocument: workerRef, merge: true)
+            } catch {
+                observer.onError(error)
+                return Disposables.create()
+            }
+            // 컬러 업데이트
+            batch.setData(["color": color], forDocument: userWorkplaceRef, merge: true)
+            batch.commit { error in
+                if let error = error {
+                    observer.onError(error)
+                } else {
+                    observer.onNext(())
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    
+    func updateWorkplaceNameAndCategory(
+        workplaceId: String,
+        name: String,
+        category: String
+    ) -> Observable<Void> {
+        let workplaceRef = db.collection("workplaces").document(workplaceId)
+        return Observable.create { observer in
+            workplaceRef.updateData([
+                "workplacesName": name,
+                "category": category
+            ]) { error in
+                if let error = error {
+                    observer.onError(error)
+                } else {
+                    observer.onNext(())
+                    observer.onCompleted()
+                }
+            }
+            return Disposables.create()
         }
     }
 }

--- a/Routory/Routory/Domain/Interfaces/Repositories/CalendarRepositoryProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/Repositories/CalendarRepositoryProtocol.swift
@@ -12,4 +12,5 @@ protocol CalendarRepositoryProtocol {
     func fetchCalendarIdByWorkplaceId(workplaceId: String) -> Observable<String?>
     func addEventToCalendar(calendarId: String, event: CalendarEvent) -> Observable<Void>
     func deleteEventFromCalendarIfPermitted(calendarId: String, eventId: String, uid: String) -> Observable<Void>
+    func updateEventInCalendar(calendarId: String, eventId: String, event: CalendarEvent) -> Observable<Void>
 }

--- a/Routory/Routory/Domain/Interfaces/Repositories/WorkplaceRepositoryProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/Repositories/WorkplaceRepositoryProtocol.swift
@@ -29,4 +29,15 @@ protocol WorkplaceRepositoryProtocol {
         month: Int
     ) -> Observable<[WorkplaceWorkSummaryDaily]>
     func deleteOrLeaveWorkplace(workplaceId: String, uid: String) -> Observable<Void>
+    func updateWorkerDetailAndColor(
+        workplaceId: String,
+        uid: String,
+        workerDetail: WorkerDetail,
+        color: String
+    ) -> Observable<Void>
+    func updateWorkplaceNameAndCategory(
+        workplaceId: String,
+        name: String,
+        category: String
+    ) -> Observable<Void>
 }

--- a/Routory/Routory/Domain/Interfaces/UseCases/CalendarUseCaseProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/UseCases/CalendarUseCaseProtocol.swift
@@ -11,4 +11,5 @@ protocol CalendarUseCaseProtocol {
     func fetchCalendarIdByWorkplaceId(workplaceId: String) -> Observable<String?>
     func addEventToCalendar(calendarId: String, event: CalendarEvent) -> Observable<Void>
     func deleteEventFromCalendarIfPermitted(calendarId: String, eventId: String, uid: String) -> Observable<Void>
+    func updateEventInCalendar(calendarId: String, eventId: String, event: CalendarEvent) -> Observable<Void>
 }

--- a/Routory/Routory/Domain/Interfaces/UseCases/WorkplaceUseCaseProtocol.swift
+++ b/Routory/Routory/Domain/Interfaces/UseCases/WorkplaceUseCaseProtocol.swift
@@ -29,4 +29,15 @@ protocol WorkplaceUseCaseProtocol {
         month: Int
     ) -> Observable<[WorkplaceWorkSummaryDaily]>
     func deleteOrLeaveWorkplace(workplaceId: String, uid: String) -> Observable<Void>
+    func updateWorkerDetailAndColor(
+        workplaceId: String,
+        uid: String,
+        workerDetail: WorkerDetail,
+        color: String
+    ) -> Observable<Void>
+    func updateWorkplaceNameAndCategory(
+        workplaceId: String,
+        name: String,
+        category: String
+    ) -> Observable<Void>
 }

--- a/Routory/Routory/Domain/UseCases/CalendarUseCase.swift
+++ b/Routory/Routory/Domain/UseCases/CalendarUseCase.swift
@@ -27,4 +27,8 @@ final class CalendarUseCase: CalendarUseCaseProtocol {
     func deleteEventFromCalendarIfPermitted(calendarId: String, eventId: String, uid: String) -> Observable<Void> {
         return repository.deleteEventFromCalendarIfPermitted(calendarId: calendarId, eventId: eventId, uid: uid)
     }
+    
+    func updateEventInCalendar(calendarId: String, eventId: String, event: CalendarEvent) -> Observable<Void> {
+        return repository.updateEventInCalendar(calendarId: calendarId, eventId: eventId, event: event)
+    }
 }

--- a/Routory/Routory/Domain/UseCases/WorkplaceUseCase.swift
+++ b/Routory/Routory/Domain/UseCases/WorkplaceUseCase.swift
@@ -58,4 +58,23 @@ final class WorkplaceUseCase: WorkplaceUseCaseProtocol {
     func deleteOrLeaveWorkplace(workplaceId: String, uid: String) -> Observable<Void> {
         return repository.deleteOrLeaveWorkplace(workplaceId: workplaceId, uid: uid)
     }
+    
+    // 알바생 기준
+    func updateWorkerDetailAndColor(
+        workplaceId: String,
+        uid: String,
+        workerDetail: WorkerDetail,
+        color: String
+    ) -> Observable<Void> {
+        return repository.updateWorkerDetailAndColor(workplaceId: workplaceId, uid: uid, workerDetail: workerDetail, color: color)
+    }
+    
+    
+    func updateWorkplaceNameAndCategory(
+        workplaceId: String,
+        name: String,
+        category: String
+    ) -> Observable<Void> {
+        return repository.updateWorkplaceNameAndCategory(workplaceId: workplaceId, name: name, category: category)
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #127 

</br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 근무지 수정 로직 구현
FireStore Security Rules으로 인해 근무지 오너일때만 이름과 카테고리 수정이 가능하게 되어있습니다. 
오너가 아닐 시 에러 반환

- 근무 수정 로직 구현
FireStore Security Rules으로 인해 근무 작성자 or 해당 캘린더의 오너가 아닐 시 에러를 반환합니다.
